### PR TITLE
Add reload delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Versions follow [Semantic Versioning](https://www.semver.org)
 ### Added
 
 - :sparkles: Typescript component generation support for functional components.
+- :wrench: Add reload delay config, wait for a moment before starting the reload watch.
 
 ## [0.6.1]
 ### Fixed

--- a/dazzler/_config.py
+++ b/dazzler/_config.py
@@ -196,6 +196,12 @@ class DazzlerConfig(Config):
             comment='Time to wait from first detected change '
                     'to actual reload.'
         )
+        reload_delay = ConfigProperty(
+            default=5.0,
+            config_type=float,
+            comment='Delay until the reloader start watching for changes.'
+                    'Some libraries changes their files when first run.'
+        )
 
     development: Development
 

--- a/dazzler/_reloader.py
+++ b/dazzler/_reloader.py
@@ -22,6 +22,7 @@ async def watch(
         on_change: typing.Callable,
         interval: float = 0.5,
         threshold: float = 3.0,
+        delay: float = 5.0
 ):
     """
     Watch for file changes in directories and files.
@@ -32,10 +33,13 @@ async def watch(
         files as first argument.
     :param interval: The rate at which to perform the change check on the files
     :param threshold: Wait time from first change til it fires reload events.
+    :param delay: Delay to sleep before starting the watch.
     :return:
     """
     timestamps = {}
     initial = True
+
+    await asyncio.sleep(delay)
 
     def handle_file(filepath):
         path = pathlib.Path(filepath)
@@ -230,5 +234,6 @@ async def start_reloader(app, reloaded=False, start_event=None):
             app.on_file_change,
             app.config.development.reload_interval,
             app.config.development.reload_threshold,
+            app.config.development.reload_delay
         )
         await app.stop()

--- a/tests/hot_reload/hot_reload_app.py
+++ b/tests/hot_reload/hot_reload_app.py
@@ -5,6 +5,7 @@ from tests.hot_reload import hot_reload_page
 app = Dazzler(__name__)
 
 app.config.session.backend = 'Redis'
+app.config.development.reload_delay = 0
 app.config.development.reload_threshold = 0.1
 app.add_page(hot_reload_page.page)
 


### PR DESCRIPTION
Some libraries like aioredis , tortoise-orm, etc. changes their files after startup resulting in a reloading loop. This adds `development.reload_delay` config option to sleep before activating the watch.